### PR TITLE
fix(requirements): fixes mlflow version to be <2.0 as it introduces b…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mlflow>=1.15.0
+mlflow>=1.15.0,<2.0
 Pillow==9.2.0
 plotly==5.9.0
 pigar==0.10.0


### PR DESCRIPTION
fixes mlflow version to be <2.0 as it introduces braking changes in the api.

This is what caused the tests to fail:

> IMPORTANT: The MLflow Model scoring protocol has changed in MLflow version 2.0. If you are seeing this error, you are likely using an outdated scoring request format. To resolve the error, either update your request format or adjust your MLflow Model's requirements file to specify an older version of MLflow (for example, change the 'mlflow' requirement specifier to 'mlflow==1.30.0'. will change th requirements to be < 2.0