### PR TITLE
feat(pynavio._mlflow): brings model prediciton schema check

### DIFF
--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -231,14 +231,15 @@ class _ModelValidator:
             assert set(model_output.keys()) == expected_keys, \
                 "please use pynavio.prediction_call to decorate " \
                 "the predict method of the model"
+        else:
 
-        prediction_key = 'prediction'
-        assert prediction_key in model_output, "model output must have" \
-               " 'prediction' as key for the target, independent of" \
-               " tha target name in the example request. There can be " \
-               "other keys, that will be listed under 'additionalFields'" \
-               "in the response of the model deployed to navio"
-        _validate_prediction_schema(model_output)
+            prediction_key = 'prediction'
+            assert prediction_key in model_output, "model output must have" \
+                   " 'prediction' as key for the target, independent of" \
+                   " tha target name in the example request. There can be " \
+                   "other keys, that will be listed under 'additionalFields'" \
+                   "in the response of the model deployed to navio"
+            _validate_prediction_schema(model_output)
 
     def __call__(self, model_path, expect_error: bool = False, **kwargs):
         model_input, model_output = self.run_model_io(model_path)

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -280,14 +280,14 @@ class _ModelValidator:
         try:
             jsonschema.validate(config.get('metadata'), METADATA_SCHEMA)
         except jsonschema.exceptions.ValidationError:
-            print(f"Error during MLmodel validation")
+            print("Error during MLmodel validation")
             raise
 
         example_request = _read_example_request(model_path, config)
         try:
             jsonschema.validate(example_request, REQUEST_SCHEMA_SCHEMA)
         except jsonschema.exceptions.ValidationError:
-            print(f"Error during example request validation")
+            print("Error during example request validation")
             raise
 
     @staticmethod

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -16,76 +16,14 @@ import jsonschema
 
 from pynavio.utils import ExampleRequestType, make_env
 from pynavio.utils.json_encoder import JSONEncoder
+from pynavio.utils.schemas import PREDICTION_SCHEMA, \
+    METADATA_SCHEMA, REQUEST_SCHEMA_SCHEMA
 
 EXAMPLE_REQUEST = 'example_request'
 ARTIFACTS = 'artifacts'
 ArtifactsType = Optional[Dict[str, str]]
 ERROR_KEYS = {'error_code', 'message', 'stack_trace'}
 PREDICTION_KEY = 'prediction'
-
-METADATA_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'request_schema': {
-            'type': 'object',
-            'properties': {
-                'path': {'type': 'string'}
-            }
-        },
-        'dataset': {
-            'type': 'object',
-            'properties': {
-                'name': {'type': 'string'},
-                'path': {'type': 'string'}
-            }
-        },
-        'oodDetection': {
-            'type': 'string',
-            'enum': ['disabled', 'default']
-        },
-        'explanations': {
-            'type': 'string',
-            'enum': ['disabled', 'default', 'plotly']
-        },
-        '.shm_mount': {'type': 'string'}
-    },
-    'required': ['request_schema']
-}
-
-COLUMN_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'name': {'type': 'string'},
-        'sampleData': {'type': [
-            'boolean', 'integer', 'number', 'array', 'string'
-        ]},
-        'type': {
-            'type': 'string',
-            'enum': ['float', 'string', 'image', 'list', 'bool', 'int',
-                     'timestamp']
-        },
-        'nullable': {'type': 'boolean'}
-    },
-    'required': ['name', 'sampleData', 'type', 'nullable']
-}
-
-REQUEST_SCHEMA_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'featureColumns': {
-            'minItems': 1,
-            'type': 'array',
-            'items': COLUMN_SCHEMA
-        },
-        'targetColumns': {
-            'minItems': 1,
-            'type': 'array',
-            'items': COLUMN_SCHEMA
-        },
-        'dateTimeColumn': COLUMN_SCHEMA
-    },
-    'required': ['featureColumns', 'targetColumns']
-}
 
 
 def _get_field(yml: dict, path: str) -> Optional[Any]:
@@ -318,35 +256,8 @@ class _ModelValidator:
     @staticmethod
     def verify_model_output(model_output, **kwargs):
         def _validate_prediction_schema(model_prediction):
-            not_sequence_prediction_types = ['boolean', 'integer',
-                                             'number', 'string']
-
-            prediction_schema = {
-                "type": "object",
-                "properties": {
-                    PREDICTION_KEY: {"oneOf":
-                                     [
-                                      {"type": not_sequence_prediction_types},
-                                      {"type": 'array',
-                                       "minItems": 1,
-                                       "items": {"type": "boolean"},
-                                       },
-                                      {"type": 'array',
-                                          "minItems": 1,
-                                          "items": {"type": "number"},
-                                       },
-                                      {"type": 'array',
-                                       "minItems": 1,
-                                       "items": {"type": "string"},
-                                       },
-                                     ]
-                                     },
-                },
-                "required": [PREDICTION_KEY],
-            }
-
             try:
-                jsonschema.validate(model_prediction, prediction_schema)
+                jsonschema.validate(model_prediction, PREDICTION_SCHEMA)
             except jsonschema.exceptions.ValidationError:
                 print(f"Error: The value of model_output['{PREDICTION_KEY}']"
                       " must be one of the following types "

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -318,7 +318,8 @@ class _ModelValidator:
     @staticmethod
     def verify_model_output(model_output, **kwargs):
         def _validate_prediction_schema(model_prediction):
-            not_sequence_prediction_types = ['boolean', 'integer', 'number', 'string']
+            not_sequence_prediction_types = ['boolean', 'integer',
+                                             'number', 'string']
             prediction_types = [
                     'array', *not_sequence_prediction_types
                 ]
@@ -350,18 +351,22 @@ class _ModelValidator:
                 jsonschema.validate(model_prediction, prediction_schema)
             except jsonschema.exceptions.ValidationError:
                 print(f"Error: The value of model_output['{PREDICTION_KEY}']"
-                      f" must be one of the following types (cannot be nested or mixed type): "
+                      " must be one of the following types "
+                      "(cannot be nested or mixed type): "
                       f"{prediction_types}")
                 raise
 
             if isinstance(model_prediction[PREDICTION_KEY], Sequence) \
                     and not isinstance(model_prediction[PREDICTION_KEY], str):
-                try:                    
-                    jsonschema.validate(model_prediction, prediction_schema_for_sequence)
+                try:
+                    jsonschema.validate(model_prediction,
+                                        prediction_schema_for_sequence)
 
                 except jsonschema.exceptions.ValidationError:
-                    print(f"Error: The value of model_output['{PREDICTION_KEY}']"
-                          f" if an array, must be an array of the following types: "
+                    print(f"Error: The value of "
+                          f"model_output['{PREDICTION_KEY}']"
+                          f" if an array, must be an array of"
+                          f" the following types: "
                           f"{not_sequence_prediction_types}")
                     raise
 

--- a/pynavio/utils/schemas.py
+++ b/pynavio/utils/schemas.py
@@ -1,0 +1,93 @@
+
+PREDICTION_KEY = 'prediction'
+not_sequence_prediction_types = ['boolean', 'integer',
+                                 'number', 'string']
+
+PREDICTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        PREDICTION_KEY: {"oneOf":
+                         [
+                          {"type": not_sequence_prediction_types},
+                          {"type": 'array',
+                           "minItems": 1,
+                           "items": {"type": "boolean"},
+                           },
+                          {"type": 'array',
+                           "minItems": 1,
+                           "items": {"type": "number"},
+                           },
+                          {"type": 'array',
+                           "minItems": 1,
+                           "items": {"type": "string"},
+                           },
+                         ]
+                         },
+    },
+    "required": [PREDICTION_KEY],
+}
+
+
+METADATA_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'request_schema': {
+            'type': 'object',
+            'properties': {
+                'path': {'type': 'string'}
+            }
+        },
+        'dataset': {
+            'type': 'object',
+            'properties': {
+                'name': {'type': 'string'},
+                'path': {'type': 'string'}
+            }
+        },
+        'oodDetection': {
+            'type': 'string',
+            'enum': ['disabled', 'default']
+        },
+        'explanations': {
+            'type': 'string',
+            'enum': ['disabled', 'default', 'plotly']
+        },
+        '.shm_mount': {'type': 'string'}
+    },
+    'required': ['request_schema']
+}
+
+COLUMN_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'name': {'type': 'string'},
+        'sampleData': {'type': [
+            'boolean', 'integer', 'number', 'array', 'string'
+        ]},
+        'type': {
+            'type': 'string',
+            'enum': ['float', 'string', 'image', 'list', 'bool', 'int',
+                     'timestamp']
+        },
+        'nullable': {'type': 'boolean'}
+    },
+    'required': ['name', 'sampleData', 'type', 'nullable']
+}
+
+REQUEST_SCHEMA_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'featureColumns': {
+            'minItems': 1,
+            'type': 'array',
+            'items': COLUMN_SCHEMA
+        },
+        'targetColumns': {
+            'minItems': 1,
+            'type': 'array',
+            'items': COLUMN_SCHEMA
+        },
+        'dateTimeColumn': COLUMN_SCHEMA
+    },
+    'required': ['featureColumns', 'targetColumns']
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mlflow>=1.15.0,<2.0
 Pillow==9.3.0
 plotly==5.9.0
 pigar==0.10.0
+jsonschema==4.4.0

--- a/tests/test_pynavio/test_mlflow.py
+++ b/tests/test_pynavio/test_mlflow.py
@@ -39,8 +39,9 @@ PREDICTION_KEY = 'prediction'
         ({PREDICTION_KEY: [{}]}),
         ({PREDICTION_KEY: [[1], [2]]}),
         ({PREDICTION_KEY: [8.5, {}]}),
-        # ({PREDICTION_KEY: [8.5, "f"]}),  # mixed types
-        # should fail too, but currently do not
+        ({PREDICTION_KEY: [8.5, "f"]}),
+        ({PREDICTION_KEY: [8.5, True]}),
+        ({PREDICTION_KEY: ["True", True]})
 
     ])
 def test_prediction_schema_check_negative(model_output):
@@ -62,7 +63,6 @@ def test_prediction_schema_check_negative(model_output):
         ({PREDICTION_KEY: ["a", "b"]}),
         ({PREDICTION_KEY: True}),
         ({PREDICTION_KEY: [True, False, True]}),
-
     ])
 def test_prediction_schema_check_positive(model_output):
     try:

--- a/tests/test_pynavio/test_mlflow.py
+++ b/tests/test_pynavio/test_mlflow.py
@@ -2,6 +2,8 @@ import pytest
 
 import pynavio
 
+import jsonschema
+
 
 @pytest.mark.parametrize(
     "args",
@@ -24,3 +26,46 @@ import pynavio
 def test_register_example_request_negative(args, tmpdir):
     with pytest.raises(AssertionError):
         pynavio.mlflow.register_example_request(tmpdir, **args)
+
+
+PREDICTION_KEY = 'prediction'
+
+
+@pytest.mark.parametrize(
+    "model_output",
+    [
+        ({PREDICTION_KEY: []}),
+        ({PREDICTION_KEY: {}}),
+        ({PREDICTION_KEY: [{}]}),
+        ({PREDICTION_KEY: [[1], [2]]}),
+        ({PREDICTION_KEY: [8.5, {}]}),
+        # ({PREDICTION_KEY: [8.5, "f"]}),  # mixed types
+        # should fail too, but currently do not
+
+    ])
+def test_prediction_schema_check_negative(model_output):
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        pynavio.mlflow._ModelValidator.verify_model_output(model_output)
+
+
+@pytest.mark.parametrize(
+    "model_output",
+    [
+        ({PREDICTION_KEY: [5]}),
+        ({PREDICTION_KEY: [5],
+          "extra key": 7,
+          "other extra": {"more info": []}}),
+        ({PREDICTION_KEY: 5}),
+        ({PREDICTION_KEY: 5.1}),
+        ({PREDICTION_KEY: [5.1, 5.0]}),
+        ({PREDICTION_KEY: "a"}),
+        ({PREDICTION_KEY: ["a", "b"]}),
+        ({PREDICTION_KEY: True}),
+        ({PREDICTION_KEY: [True, False, True]}),
+
+    ])
+def test_prediction_schema_check_positive(model_output):
+    try:
+        pynavio.mlflow._ModelValidator.verify_model_output(model_output)
+    except(jsonschema.exceptions.ValidationError, AssertionError):
+        pytest.fail("Unexpected Exception")


### PR DESCRIPTION
This pr

- is **publicly visible**.
- is related to NAVIO_1538.
- is intended to add schema & type checks mentioned in the previous [pr](https://github.com/craftworksgmbh/craftworks-pynavio/pull/51) (on top of which it is created)

- [x]  (verify_model_output): check that the output is a dict 
- [x] (verify_model_output): check that the prediction is mapping to a number, string, bool or list
- [x] verify the example request (and MLmodel metadata) against the expected schema
 
