### PR TITLE
Feat/navio 1538 loosen version requirement for jsonschema

### DIFF
--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -237,16 +237,20 @@ class _ModelValidator:
 
     @staticmethod
     def _check_if_prediction_call_is_used(model_path):
+
         model = mlflow.pyfunc.load_model(model_path)
         corrupt_model_input = pd.DataFrame(
             {'corrupt_model_input_123': [1, 2, 3]})
+
+        error_msg = \
+            "Please use pynavio.prediction_call to decorate " \
+            "the predict method of the model, which will add the " \
+            "needed error keys for error case"
         try:
             model_output = model.predict(corrupt_model_input)
         except Exception:
-            print("Please use pynavio.prediction_call to decorate "
-                  "the predict method of the model, which will add the "
-                  "needed error keys for error case")
-            raise ValueError
+            print(error_msg)
+            raise KeyError(error_msg)
 
         assert isinstance(model_output, Mapping), "Model " \
             "output has to be a dictionary"
@@ -254,10 +258,7 @@ class _ModelValidator:
         if PREDICTION_KEY not in model_output:  # precaution
             # to allow for models that always return prediction
 
-            assert set(model_output.keys()) == ERROR_KEYS, \
-                "Please use pynavio.prediction_call to decorate " \
-                "the predict method of the model, which will add the " \
-                "needed error keys for error case"
+            assert set(model_output.keys()) == ERROR_KEYS, error_msg
 
     @staticmethod
     def verify_model_output(model_output, **kwargs):

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -242,17 +242,24 @@ class _ModelValidator:
         corrupt_model_input = pd.DataFrame(
             {'corrupt_model_input_123': [1, 2, 3]})
 
+        import logging
+        logger = logging.getLogger('gunicorn.error')
+        current_loglevel = logger.level
+        logger.setLevel(logging.CRITICAL)  # this is done to prevent
+        # logging the exception traceback from prediction call
+        # as it will be confusing for the user
+
         error_msg = \
             "Please use pynavio.prediction_call to decorate " \
             "the predict method of the model, which will add the " \
             "needed error keys for error case"
-        print("\n Info: Providing corrupt input to the model to try to"
-              " check if pynavio.prediction_call is used")
         try:
             model_output = model.predict(corrupt_model_input)
         except Exception:
             print(error_msg)
             raise KeyError(error_msg)
+        finally:
+            logger.setLevel(current_loglevel)
 
         assert isinstance(model_output, Mapping), "Model " \
             "output has to be a dictionary"

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -275,7 +275,7 @@ class _ModelValidator:
                 f"The model output has to contain '{PREDICTION_KEY}'" \
                 f" for prediction" \
                 f" as key for the target, independent of" \
-                f" tha target name in the example request" \
+                f" the target name in the example request" \
                 f". There can be other keys, " \
                 f" that will be listed under " \
                 f" 'additionalFields' in the response of the model " \

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -246,6 +246,8 @@ class _ModelValidator:
             "Please use pynavio.prediction_call to decorate " \
             "the predict method of the model, which will add the " \
             "needed error keys for error case"
+        print("\n Info: Providing corrupt input to the model to try to"
+              " check if pynavio.prediction_call is used")
         try:
             model_output = model.predict(corrupt_model_input)
         except Exception:

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -237,6 +237,11 @@ class _ModelValidator:
 
     @staticmethod
     def _check_if_prediction_call_is_used(model_path):
+        # In order to check if the pynavio.prediction_call
+        # is used to decorate the predict method of the model,
+        # a corrupt input is provided. If there is an exception
+        # or the expected keys are not present in the model output,
+        # then that means that the decorator is not applied
 
         model = mlflow.pyfunc.load_model(model_path)
         corrupt_model_input = pd.DataFrame(

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -256,7 +256,6 @@ class _ModelValidator:
         try:
             model_output = model.predict(corrupt_model_input)
         except Exception:
-            print(error_msg)
             raise KeyError(error_msg)
         finally:
             logger.setLevel(current_loglevel)

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -286,7 +286,7 @@ class _ModelValidator:
                 " structure',} }"\
                 f" in the response of the model deployed" \
                 f" to navio."\
-                f" Or The model output has to contain and the following" \
+                f" Or The model output has to contain the following" \
                 f" keys [{ERROR_KEYS}] if error occurs."\
                 f"Please use pynavio.prediction_call to decorate " \
                 f"the predict method of the model, which will add the " \

--- a/pynavio/_mlflow.py
+++ b/pynavio/_mlflow.py
@@ -240,7 +240,13 @@ class _ModelValidator:
         model = mlflow.pyfunc.load_model(model_path)
         corrupt_model_input = pd.DataFrame(
             {'corrupt_model_input_123': [1, 2, 3]})
-        model_output = model.predict(corrupt_model_input)
+        try:
+            model_output = model.predict(corrupt_model_input)
+        except Exception:
+            print("Please use pynavio.prediction_call to decorate "
+                  "the predict method of the model, which will add the "
+                  "needed error keys for error case")
+            raise ValueError
 
         assert isinstance(model_output, Mapping), "Model " \
             "output has to be a dictionary"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mlflow>=1.15.0,<2.0
 Pillow==9.3.0
 plotly==5.9.0
 pigar==0.10.0
-jsonschema==4.4.0
+jsonschema>=3.2.0


### PR DESCRIPTION
- This pr is **public**
- loosening the requirement as I have run into a dependency conflict with the existing fixed version of 4.4.0:
 `docker-compose 1.29.1 requires jsonschema<4,>=2.5.1, but you have jsonschema 4.4.0 which is incompatible.`
- removes a redundant 'and' from an error message text, and fixes a typo in an  error message text
- **changes the exception handling and adds descriptive error text for cases where the prediction call decorator is not used** , also a print out message to explain the stack trace printout that is caused by this check
